### PR TITLE
remove URI encoding for / in url

### DIFF
--- a/router.js
+++ b/router.js
@@ -150,7 +150,7 @@ AmorphicRouter =
                 this.location.hash = '';
                 this.history.pushState(route.__path, route.__title ? route.__title : null, this._encodeURL(route));
             } else
-                this.location.hash = '#' + encodeURIComponent(this._encodeURL(route));
+                this.location.hash = '#' + this._encodeURL(route);
         }
     },
 


### PR DESCRIPTION
Currently routes appear as: https://havenlife.com/#%2Fneeds
Routes will now appear as: https://havenlife.com/#/needs

`_encodeURL` will already encode the route, no need to run again and encode the `/`